### PR TITLE
fix contrast issue of status bar in debug mode (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.6] - 2021-02-13
+
+### Changed
+
+- Update background and foreground colors of color status for debugging mode (fixes #6).
+
 ## [2.5.5] - 2021-02-11
 
 ### Updated

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "alternight",
   "displayName": "AlterNight",
   "description": "A Visual Studio Code theme for those who code at night",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "publisher": "spaceinvadev",
   "author": {
     "name": "Mauricio Paternina",

--- a/themes/alternight-color-theme.json
+++ b/themes/alternight-color-theme.json
@@ -51,6 +51,8 @@
     "statusBar.background": "#1f172b",
     "statusBar.foreground": "#9077b6",
     "statusBarItem.hoverBackground": "#14141472",
+    "statusBar.debuggingBackground": "#e29fa4",
+    "statusBar.debuggingForeground": "#1f172b",
 
     // Integrated Terminal
     "terminal.background": "#1f172b",


### PR DESCRIPTION
Define foreground and background colors for the status bar to prevent a color contrast issue. Fixes #6 